### PR TITLE
Event stream client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-LiteFS Go Library
+LiteFS Go Library [![Go Reference](https://pkg.go.dev/badge/github.com/superfly/litefs-go.svg)](https://pkg.go.dev/github.com/superfly/litefs-go)
 =================
 
 This Go library is for interacting with LiteFS features that cannot be accessed

--- a/client.go
+++ b/client.go
@@ -1,0 +1,67 @@
+package litefs
+
+import (
+	"context"
+	"net/http"
+)
+
+// SubscribeEvents subscribes to events from the default (localhost:20202)
+// LiteFS node.
+func SubscribeEvents() *EventSubscription {
+	return DefaultClient.SubscribeEvents()
+}
+
+// MonitorPrimary monitors the primary status of the LiteFS cluster via the
+// default (localhost:20202) LiteFS node's event stream.
+func MonitorPrimary() *PrimaryMonitor {
+	return DefaultClient.MonitorPrimary()
+}
+
+// Client is an HTTP client for communicating with a LiteFS node.
+type Client struct {
+	// Base URL of the LiteFS cluster node.
+	URL string
+
+	// HTTP client to use for requests to cluster node.
+	HTTP *http.Client
+}
+
+// DefaultClient is a client for communicating with the default
+// (localhost:20202) LiteFS node.
+var DefaultClient = &Client{
+	URL:  "http://localhost:20202",
+	HTTP: http.DefaultClient,
+}
+
+// SubscribeEvents subscribes to events from the LiteFS node.
+func (c *Client) SubscribeEvents() *EventSubscription {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &EventSubscription{
+		c:         c,
+		ctx:       ctx,
+		cancelCtx: cancel,
+	}
+}
+
+// MonitorPrimary monitors the primary status of the LiteFS cluster via the
+// LiteFS node's event stream.
+func (c *Client) MonitorPrimary() *PrimaryMonitor {
+	pm := &PrimaryMonitor{
+		es:    c.SubscribeEvents(),
+		ready: make(chan struct{}),
+	}
+
+	go pm.run()
+
+	return pm
+}
+
+func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.URL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.HTTP.Do(req)
+}

--- a/client.go
+++ b/client.go
@@ -5,18 +5,6 @@ import (
 	"net/http"
 )
 
-// SubscribeEvents subscribes to events from the default (localhost:20202)
-// LiteFS node.
-func SubscribeEvents() EventSubscription {
-	return DefaultClient.SubscribeEvents()
-}
-
-// MonitorPrimary monitors the primary status of the LiteFS cluster via the
-// default (localhost:20202) LiteFS node's event stream.
-func MonitorPrimary() PrimaryMonitor {
-	return DefaultClient.MonitorPrimary()
-}
-
 // Client is an HTTP client for communicating with a LiteFS node.
 type Client struct {
 	// Base URL of the LiteFS cluster node.

--- a/client.go
+++ b/client.go
@@ -7,13 +7,13 @@ import (
 
 // SubscribeEvents subscribes to events from the default (localhost:20202)
 // LiteFS node.
-func SubscribeEvents() *EventSubscription {
+func SubscribeEvents() EventSubscription {
 	return DefaultClient.SubscribeEvents()
 }
 
 // MonitorPrimary monitors the primary status of the LiteFS cluster via the
 // default (localhost:20202) LiteFS node's event stream.
-func MonitorPrimary() *PrimaryMonitor {
+func MonitorPrimary() PrimaryMonitor {
 	return DefaultClient.MonitorPrimary()
 }
 
@@ -34,10 +34,10 @@ var DefaultClient = &Client{
 }
 
 // SubscribeEvents subscribes to events from the LiteFS node.
-func (c *Client) SubscribeEvents() *EventSubscription {
+func (c *Client) SubscribeEvents() EventSubscription {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	return &EventSubscription{
+	return &eventSubscription{
 		c:         c,
 		ctx:       ctx,
 		cancelCtx: cancel,
@@ -46,8 +46,8 @@ func (c *Client) SubscribeEvents() *EventSubscription {
 
 // MonitorPrimary monitors the primary status of the LiteFS cluster via the
 // LiteFS node's event stream.
-func (c *Client) MonitorPrimary() *PrimaryMonitor {
-	pm := &PrimaryMonitor{
+func (c *Client) MonitorPrimary() PrimaryMonitor {
+	pm := &primaryMonitor{
 		es:    c.SubscribeEvents(),
 		ready: make(chan struct{}),
 	}

--- a/event.go
+++ b/event.go
@@ -1,0 +1,72 @@
+package litefs
+
+import (
+	"encoding/json"
+	"time"
+)
+
+////
+// copied from litefs repo.
+// modifications are commented.
+
+const (
+	EventTypeInit          = "init"
+	EventTypeTx            = "tx"
+	EventTypePrimaryChange = "primaryChange"
+)
+
+// Event represents a generic event.
+type Event struct {
+	Type string `json:"type"`
+	DB   string `json:"db,omitempty"`
+	Data any    `json:"data,omitempty"`
+}
+
+func (e *Event) UnmarshalJSON(data []byte) error {
+	var v eventJSON
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	e.Type = v.Type
+	e.DB = v.DB
+
+	switch v.Type {
+	case EventTypeInit:
+		e.Data = &InitEventData{}
+	case EventTypeTx:
+		e.Data = &TxEventData{}
+	case EventTypePrimaryChange:
+		e.Data = &PrimaryChangeEventData{}
+	default:
+		e.Data = nil
+	}
+	if err := json.Unmarshal(v.Data, &e.Data); err != nil {
+		return err
+	}
+	return nil
+}
+
+type eventJSON struct {
+	Type string          `json:"type"`
+	DB   string          `json:"db,omitempty"`
+	Data json.RawMessage `json:"data,omitempty"`
+}
+
+type InitEventData struct {
+	IsPrimary bool   `json:"isPrimary"`
+	Hostname  string `json:"hostname,omitempty"`
+}
+
+type TxEventData struct {
+	TXID              string    `json:"txID"`              // ltx.TXID
+	PostApplyChecksum string    `json:"postApplyChecksum"` // ltx.Checksum
+	PageSize          uint32    `json:"pageSize"`
+	Commit            uint32    `json:"commit"`
+	Timestamp         time.Time `json:"timestamp"`
+}
+
+type PrimaryChangeEventData struct {
+	IsPrimary bool   `json:"isPrimary"`
+	Hostname  string `json:"hostname,omitempty"`
+}

--- a/event_subscription.go
+++ b/event_subscription.go
@@ -1,0 +1,99 @@
+package litefs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+var (
+	EventSubscriptionClient = http.DefaultClient
+	EventSubscriptionURL    = "http://localhost:20202/events"
+)
+
+var (
+	errUnexpectedStatus = errors.New("unexpected status")
+)
+
+// EventSubscription tracks events published by a LiteFS node.
+type EventSubscription struct {
+	c     chan *Event
+	errc  chan error
+	ctx   context.Context
+	close func()
+}
+
+func SubscribeEvents() *EventSubscription {
+	ctx, close := context.WithCancel(context.Background())
+
+	es := &EventSubscription{
+		c:     make(chan *Event),
+		errc:  make(chan error),
+		ctx:   ctx,
+		close: close,
+	}
+
+	go es.run()
+
+	return es
+}
+
+func (es *EventSubscription) run() {
+	defer close(es.c)
+	defer close(es.errc)
+
+	for {
+		err := es.doRequest()
+		if es.ctx.Err() != nil {
+			return
+		}
+
+		es.errc <- err
+	}
+}
+
+func (es *EventSubscription) doRequest() error {
+	req, err := http.NewRequestWithContext(es.ctx, http.MethodGet, EventSubscriptionURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := EventSubscriptionClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %d", errUnexpectedStatus, resp.StatusCode)
+	}
+
+	d := json.NewDecoder(resp.Body)
+	for {
+		var e Event
+		if err := d.Decode(&e); err != nil {
+			return err
+		}
+
+		es.c <- &e
+	}
+}
+
+// C returns a chan of events from the local LiteFS node.
+func (es *EventSubscription) C() <-chan *Event {
+	return es.c
+}
+
+// ErrC returns a chan of errors encountered while fetching events from the
+// local LiteFS node.
+func (es *EventSubscription) ErrC() <-chan error {
+	return es.errc
+}
+
+// Close shuts down the EventSubscription.
+func (es *EventSubscription) Close() {
+	es.close()
+}

--- a/event_subscription_test.go
+++ b/event_subscription_test.go
@@ -119,7 +119,7 @@ var (
 	pChangeNode2Event = &Event{Type: EventTypePrimaryChange, Data: &PrimaryChangeEventData{IsPrimary: false, Hostname: "node-2"}}
 )
 
-func mockServerSubscription(t *testing.T, resps ...string) *EventSubscription {
+func mockServerSubscription(t *testing.T, resps ...string) EventSubscription {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for len(resps) != 0 {
 			if r.Context().Err() != nil {
@@ -159,7 +159,7 @@ func mockServerSubscription(t *testing.T, resps ...string) *EventSubscription {
 	return es
 }
 
-func assertReadEvent(t *testing.T, es *EventSubscription, expected *Event) {
+func assertReadEvent(t *testing.T, es EventSubscription, expected *Event) {
 	t.Helper()
 
 	event, err := es.Next()

--- a/event_subscription_test.go
+++ b/event_subscription_test.go
@@ -1,0 +1,193 @@
+package litefs
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func ExampleSubscribeEvents() {
+	// setup fake events endpoint
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"type":"init","data":{"isPrimary":true,"hostname":"node-1"}}`)
+		fmt.Fprintln(w, `{"type":"primaryChange","data":{"isPrimary":false,"hostname":"node-2"}}`)
+	}))
+	defer server.Close()
+	EventSubscriptionURL = server.URL
+
+	subscriber := SubscribeEvents()
+	defer subscriber.Close()
+
+	for {
+		select {
+		case event := <-subscriber.C():
+			switch data := event.Data.(type) {
+			case *InitEventData:
+				fmt.Printf("init: isPrimary=%t hostname=%s\n", data.IsPrimary, data.Hostname)
+			case *PrimaryChangeEventData:
+				fmt.Printf("primary change: isPrimary=%t hostname=%s\n", data.IsPrimary, data.Hostname)
+			case *TxEventData:
+				fmt.Printf("tx: %s\n", data.TXID)
+			}
+		case err := <-subscriber.ErrC():
+			fmt.Println(err)
+			return
+		}
+	}
+
+	// Output: init: isPrimary=true hostname=node-1
+	// primary change: isPrimary=false hostname=node-2
+	// EOF
+}
+
+func TestEventStream(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		es := mockServerSubscription(t,
+			initEventJSON, flush, sleep10,
+			txEventJSON, flush, sleep10,
+			pChangeNode2EventJSON,
+		)
+
+		assertReadEvent(t, es, initEvent)
+		assertReadEvent(t, es, txEvent)
+		assertReadEvent(t, es, pChangeNode2Event)
+	})
+
+	t.Run("error status", func(t *testing.T) {
+		es := mockServerSubscription(t,
+			status500,
+			initEventJSON, flush, sleep10,
+		)
+
+		select {
+		case <-es.C():
+			t.Fatal("expected error")
+		case err := <-es.ErrC():
+			if !errors.Is(err, errUnexpectedStatus) {
+				t.Fatalf("expected errUnexpectedStatus, got %s", err)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout")
+		}
+
+		assertReadEvent(t, es, initEvent)
+	})
+
+	t.Run("premature hangup", func(t *testing.T) {
+		es := mockServerSubscription(t,
+			initEventJSON, flush, sleep10,
+			hangup,
+			initEventJSON, flush, sleep10,
+		)
+
+		assertReadEvent(t, es, initEvent)
+
+		select {
+		case <-es.C():
+			t.Fatal("expected error")
+		case err := <-es.ErrC():
+			if err.Error() != "unexpected EOF" {
+				t.Fatalf("expected errUnexpectedStatus, got %s", err)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout")
+		}
+
+		assertReadEvent(t, es, initEvent)
+	})
+
+	t.Run("bad response", func(t *testing.T) {
+		es := mockServerSubscription(t,
+			"beep boop", flush, sleep10,
+			initEventJSON, flush, sleep10,
+		)
+
+		select {
+		case <-es.C():
+			t.Fatal("expected error")
+		case err := <-es.ErrC():
+			jerr := new(json.SyntaxError)
+			if !errors.As(err, &jerr) {
+				t.Fatalf("expected json.SyntaxError, got %s", err)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("timeout")
+		}
+
+		assertReadEvent(t, es, initEvent)
+	})
+}
+
+const (
+	status500             = "status500"
+	hangup                = "hangup"
+	sleep10               = "sleep10"
+	flush                 = "flush"
+	initEventJSON         = `{"type":"init","data":{"isPrimary":true,"hostname":"node-1"}}`
+	txEventJSON           = `{"type":"tx","db":"db","data":{"txID":"0000000000000027","postApplyChecksum":"83b05248774ce767","pageSize":4096,"commit":2,"timestamp":"0001-01-01T00:00:00Z"}}`
+	pChangeNode2EventJSON = `{"type":"primaryChange","data":{"isPrimary":false,"hostname":"node-2"}}`
+	pChangeNode1EventJSON = `{"type":"primaryChange","data":{"isPrimary":true,"hostname":"node-1"}}`
+)
+
+var (
+	initEvent         = &Event{Type: EventTypeInit, Data: &InitEventData{IsPrimary: true, Hostname: "node-1"}}
+	txEvent           = &Event{Type: EventTypeTx, DB: "db", Data: &TxEventData{TXID: "0000000000000027", PostApplyChecksum: "83b05248774ce767", PageSize: 4096, Commit: 2}}
+	pChangeNode2Event = &Event{Type: EventTypePrimaryChange, Data: &PrimaryChangeEventData{IsPrimary: false, Hostname: "node-2"}}
+	pChangeNode1Event = &Event{Type: EventTypePrimaryChange, Data: &PrimaryChangeEventData{IsPrimary: true, Hostname: "node-1"}}
+)
+
+func mockServerSubscription(t *testing.T, resps ...string) *EventSubscription {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for len(resps) != 0 {
+			if r.Context().Err() != nil {
+				return
+			}
+
+			resp := resps[0]
+			resps = resps[1:]
+
+			switch resp {
+			case status500:
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			case hangup:
+				conn, _, _ := w.(http.Hijacker).Hijack()
+				conn.Close()
+				return
+			case sleep10:
+				time.Sleep(10 * time.Millisecond)
+			case flush:
+				w.(http.Flusher).Flush()
+			default:
+				fmt.Fprintln(w, resp)
+			}
+		}
+	}))
+	t.Cleanup(s.Close)
+	EventSubscriptionURL = s.URL
+
+	es := SubscribeEvents()
+	t.Cleanup(es.Close)
+
+	return es
+}
+
+func assertReadEvent(t *testing.T, es *EventSubscription, expected *Event) {
+	t.Helper()
+
+	select {
+	case event := <-es.C():
+		if !reflect.DeepEqual(event, expected) {
+			t.Fatalf("wrong event\nexpected: %#v\nactual:%#v", expected, event)
+		}
+	case err := <-es.ErrC():
+		t.Fatalf("unexpected error: %s", err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout")
+	}
+}

--- a/litefs_test.go
+++ b/litefs_test.go
@@ -1,0 +1,47 @@
+package litefs
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestLag(t *testing.T) {
+	const lagFmt = "%+010d\n"
+
+	var (
+		dbDir   = t.TempDir()
+		dbPath  = dbDir + "/foo.db"
+		lagPath = dbDir + "/.lag"
+	)
+
+	if _, err := Lag(dbPath); err == nil {
+		t.Fatal("expected error")
+	}
+
+	os.WriteFile(lagPath, []byte("hi"), 0o666)
+	if _, err := Lag(dbPath); err == nil {
+		t.Fatal("expected error")
+	}
+
+	os.WriteFile(lagPath, []byte(fmt.Sprintf(lagFmt, math.MaxInt32)), 0o666)
+	if _, err := Lag(dbPath); err != errNotReplicated {
+		t.Fatalf("expected errNotReplicated, got %v", err)
+	}
+
+	os.WriteFile(lagPath, []byte(fmt.Sprintf(lagFmt, 0)), 0o666)
+	if lag, err := Lag(dbPath); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	} else if lag != 0 {
+		t.Fatalf("expected 0ms, got %v", lag)
+	}
+
+	os.WriteFile(lagPath, []byte(fmt.Sprintf(lagFmt, 123)), 0o666)
+	if lag, err := Lag(dbPath); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	} else if lag != 123*time.Millisecond {
+		t.Fatalf("expected 0ms, got %v", lag)
+	}
+}

--- a/primary_monitor.go
+++ b/primary_monitor.go
@@ -1,0 +1,136 @@
+package litefs
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var (
+	ErrNotReady = errors.New("awaiting first event")
+	ErrClosed   = errors.New("PrimaryMonitor closed")
+)
+
+// PrimaryMonitor monitors the current primary status of the LiteFS cluster.
+type PrimaryMonitor struct {
+	es    *EventSubscription
+	ready chan struct{}
+	m     sync.RWMutex
+
+	isPrimary bool
+	hostname  string
+	err       error
+}
+
+// NewPrimaryMonitor returns a new *PrimaryMonitor.
+func NewPrimaryMonitor() *PrimaryMonitor {
+	pm := &PrimaryMonitor{
+		es:    SubscribeEvents(),
+		ready: make(chan struct{}),
+	}
+
+	go pm.run()
+
+	return pm
+}
+
+// WaitReady blocks until ctx expires or a response or error has been received
+// from the local LiteFS node. IsPrimary and Hostname will return errors until
+// this method returns nil.
+func (pm *PrimaryMonitor) WaitReady(ctx context.Context) error {
+	select {
+	case <-pm.ready:
+		pm.m.RLock()
+		defer pm.m.RUnlock()
+		return pm.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// IsPrimary reports whether the local node is primary node in the cluster. An
+// error is returned if this method is called before data has been received
+// from the local LiteFS node (see WaitReady). If an error is encountered while
+// communicating with the local node, that error, along with the most recent
+// IsPrimary value will be returned.
+func (pm *PrimaryMonitor) IsPrimary() (bool, error) {
+	select {
+	case <-pm.ready:
+	default:
+		return false, ErrNotReady
+	}
+
+	pm.m.RLock()
+	defer pm.m.RUnlock()
+
+	return pm.isPrimary, pm.err
+}
+
+// Hostname reports the name of the current primary node in the cluster. An
+// error is returned if this method is called before data has been received
+// from the local LiteFS node (see WaitReady). If an error is encountered while
+// communicating with the local node, that error, along with the most recent
+// Hostname value will be returned.
+func (pm *PrimaryMonitor) Hostname() (string, error) {
+	select {
+	case <-pm.ready:
+	default:
+		return "", ErrNotReady
+	}
+
+	pm.m.RLock()
+	defer pm.m.RUnlock()
+
+	return pm.hostname, pm.err
+}
+
+// Close unsubscribes to the local LiteFS node's event stream.
+func (pm *PrimaryMonitor) Close() {
+	pm.es.Close()
+	pm.setError(ErrClosed)
+}
+
+func (pm *PrimaryMonitor) run() {
+	first := true
+
+	for {
+		select {
+		case event, running := <-pm.es.C():
+			if !running {
+				return
+			}
+			switch data := event.Data.(type) {
+			case *InitEventData:
+				pm.setData(data.IsPrimary, data.Hostname)
+			case *PrimaryChangeEventData:
+				pm.setData(data.IsPrimary, data.Hostname)
+			}
+		case err, running := <-pm.es.ErrC():
+			if !running {
+				return
+			}
+			pm.setError(err)
+		}
+
+		if first {
+			close(pm.ready)
+			first = false
+		}
+	}
+}
+
+func (pm *PrimaryMonitor) setData(isPrimary bool, hostname string) {
+	pm.m.Lock()
+	defer pm.m.Unlock()
+
+	pm.isPrimary = isPrimary
+	pm.hostname = hostname
+	pm.err = nil
+}
+
+func (pm *PrimaryMonitor) setError(err error) {
+	pm.m.Lock()
+	defer pm.m.Unlock()
+
+	pm.err = err
+}

--- a/primary_monitor_test.go
+++ b/primary_monitor_test.go
@@ -94,7 +94,7 @@ func TestPrimaryMonitor(t *testing.T) {
 	})
 }
 
-func assertReady(t *testing.T, pm *PrimaryMonitor, to time.Duration) {
+func assertReady(t *testing.T, pm PrimaryMonitor, to time.Duration) {
 	t.Helper()
 
 	ctx, cancel := context.WithTimeout(context.Background(), to)
@@ -105,7 +105,7 @@ func assertReady(t *testing.T, pm *PrimaryMonitor, to time.Duration) {
 	}
 }
 
-func assertPrimary(t *testing.T, pm *PrimaryMonitor, expectedIP bool, expectedHN string) {
+func assertPrimary(t *testing.T, pm PrimaryMonitor, expectedIP bool, expectedHN string) {
 	t.Helper()
 	time.Sleep(5 * time.Millisecond)
 
@@ -126,7 +126,7 @@ func assertPrimary(t *testing.T, pm *PrimaryMonitor, expectedIP bool, expectedHN
 	}
 }
 
-func mockServerMonitor(t *testing.T) (*PrimaryMonitor, chan string) {
+func mockServerMonitor(t *testing.T) (PrimaryMonitor, chan string) {
 	c := make(chan string)
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/primary_monitor_test.go
+++ b/primary_monitor_test.go
@@ -153,10 +153,15 @@ func mockServerMonitor(t *testing.T) (*PrimaryMonitor, chan string) {
 		}
 	}))
 	t.Cleanup(s.Close)
-	EventSubscriptionURL = s.URL
 
-	pm := NewPrimaryMonitor()
+	client := &Client{
+		URL:  s.URL,
+		HTTP: s.Client(),
+	}
+
+	pm := client.MonitorPrimary()
 	t.Cleanup(pm.Close)
+
 	t.Cleanup(func() { close(c) })
 
 	return pm, c

--- a/primary_monitor_test.go
+++ b/primary_monitor_test.go
@@ -1,0 +1,163 @@
+package litefs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestPrimaryMonitor(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		pm, c := mockServerMonitor(t)
+
+		c <- initEventJSON
+		c <- flush
+		assertReady(t, pm, 5*time.Millisecond)
+		assertPrimary(t, pm, true, "node-1")
+
+		c <- pChangeNode2EventJSON
+		c <- flush
+		assertPrimary(t, pm, false, "node-2")
+
+		c <- pChangeNode1EventJSON
+		c <- flush
+		assertPrimary(t, pm, true, "node-1")
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		pm, c := mockServerMonitor(t)
+
+		c <- initEventJSON
+		c <- flush
+		assertReady(t, pm, 5*time.Millisecond)
+		assertPrimary(t, pm, true, "node-1")
+
+		c <- hangup
+		c <- status500
+		time.Sleep(5 * time.Millisecond)
+
+		hn, err := pm.Hostname()
+		if !errors.Is(err, errUnexpectedStatus) {
+			t.Fatalf("expected errUnexpectedStatus, got %v", err)
+		}
+		if hn != "node-1" {
+			t.Fatalf("expected node-1, got %s", hn)
+		}
+
+		ip, err := pm.IsPrimary()
+		if !errors.Is(err, errUnexpectedStatus) {
+			t.Fatalf("expected errUnexpectedStatus, got %v", err)
+		}
+		if !ip {
+			t.Fatal("expected isPrimary")
+		}
+
+		c <- initEventJSON
+		c <- flush
+		assertPrimary(t, pm, true, "node-1")
+	})
+
+	t.Run("WaitReady timeout", func(t *testing.T) {
+		pm, c := mockServerMonitor(t)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		err := pm.WaitReady(ctx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected DeadlineExceeded, got %v", err)
+		}
+
+		c <- initEventJSON
+		c <- flush
+		assertReady(t, pm, 5*time.Millisecond)
+		assertPrimary(t, pm, true, "node-1")
+	})
+
+	t.Run("WaitReady server error", func(t *testing.T) {
+		pm, c := mockServerMonitor(t)
+
+		c <- status500
+
+		err := pm.WaitReady(context.Background())
+		if !errors.Is(err, errUnexpectedStatus) {
+			t.Fatalf("expected errUnexpectedStatus, got %v", err)
+		}
+
+		c <- initEventJSON
+		c <- flush
+		assertPrimary(t, pm, true, "node-1")
+	})
+}
+
+func assertReady(t *testing.T, pm *PrimaryMonitor, to time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), to)
+	defer cancel()
+
+	if err := pm.WaitReady(ctx); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func assertPrimary(t *testing.T, pm *PrimaryMonitor, expectedIP bool, expectedHN string) {
+	t.Helper()
+	time.Sleep(5 * time.Millisecond)
+
+	hn, err := pm.Hostname()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if hn != expectedHN {
+		t.Fatalf("expected %s, got %s", expectedHN, hn)
+	}
+
+	ip, err := pm.IsPrimary()
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if ip != expectedIP {
+		t.Fatalf("expected %t, got %t", expectedIP, ip)
+	}
+}
+
+func mockServerMonitor(t *testing.T) (*PrimaryMonitor, chan string) {
+	c := make(chan string)
+
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Context().Err() != nil {
+			return
+		}
+
+		for resp := range c {
+			switch resp {
+			case status500:
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			case hangup:
+				conn, _, _ := w.(http.Hijacker).Hijack()
+				conn.Close()
+				return
+			case sleep10:
+				time.Sleep(10 * time.Millisecond)
+			case flush:
+				w.(http.Flusher).Flush()
+			default:
+				fmt.Fprintln(w, resp)
+			}
+		}
+	}))
+	t.Cleanup(s.Close)
+	EventSubscriptionURL = s.URL
+
+	pm := NewPrimaryMonitor()
+	t.Cleanup(pm.Close)
+	t.Cleanup(func() { close(c) })
+
+	return pm, c
+}


### PR DESCRIPTION
This PR adds client APIs for working with the event streams added in https://github.com/superfly/litefs/pull/401. A lower level `EventSubscription` type is added for subscribing to raw events. More generally useful is the `PrimaryMonitor` type that continuously monitors the event stream for changes in the cluster primary, allowing current information about the primary to be fetched immediately.

[Here's](https://pkg.go.dev/github.com/superfly/litefs-go@v0.0.0-20230912191152-2a50fa5cd065) a preview of the godocs.